### PR TITLE
Add 3D multi-layer board and proper Three.js resource disposal

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,15 @@
             board: 0x8b4513,
             boardLight: 0xcd853f
         };
+
+        function getLayerColor(y, variant = 0) {
+            const hue = (y / Math.max(boardDepth, 1)) * 0.85;
+            const saturation = 0.55;
+            const lightness = variant === 0 ? 0.46 : 0.60;
+            const color = new THREE.Color();
+            color.setHSL(hue, saturation, lightness);
+            return color.getHex();
+        }
         
         // Number colors
         const NUMBER_COLORS = [
@@ -331,7 +340,7 @@
                         const isLight = (x + y + z) % 2 === 0;
                         const geometry = new THREE.BoxGeometry(cellSize, 0.5, cellSize);
                         const material = new THREE.MeshStandardMaterial({ 
-                            color: isLight ? COLORS.boardLight : COLORS.board,
+                            color: isLight ? getLayerColor(y, 1) : getLayerColor(y, 0),
                             roughness: 0.7
                         });
                         const cell = new THREE.Mesh(geometry, material);
@@ -718,14 +727,14 @@
                 const cell = intersects[0].object;
                 if (hoveredCell !== cell && !cell.userData.revealed) {
                     if (hoveredCell) {
-                        hoveredCell.material.color.setHex(hoveredCell.userData.isLight ? COLORS.boardLight : COLORS.board);
+                        hoveredCell.material.color.setHex(hoveredCell.userData.isLight ? getLayerColor(hoveredCell.userData.y, 1) : getLayerColor(hoveredCell.userData.y, 0));
                     }
                     hoveredCell = cell;
                     hoveredCell.material.color.setHex(COLORS.cellHover);
                 }
             } else {
                 if (hoveredCell) {
-                    hoveredCell.material.color.setHex(hoveredCell.userData.isLight ? COLORS.boardLight : COLORS.board);
+                    hoveredCell.material.color.setHex(hoveredCell.userData.isLight ? getLayerColor(hoveredCell.userData.y, 1) : getLayerColor(hoveredCell.userData.y, 0));
                     hoveredCell = null;
                 }
             }

--- a/index.html
+++ b/index.html
@@ -197,6 +197,7 @@
         let scene, camera, renderer, controls;
         let cells = [];
         let boardSize = 12;
+        let boardDepth = 3;
         let mineCount = 20;
         let flagsPlaced = 0;
         let gameOver = false;
@@ -282,6 +283,21 @@
             animate();
         }
         
+        function disposeObject3D(object) {
+            if (!object) return;
+            if (object.material) {
+                const materials = Array.isArray(object.material) ? object.material : [object.material];
+                materials.forEach(material => {
+                    if (!material) return;
+                    if (material.map) material.map.dispose();
+                    material.dispose();
+                });
+            }
+            if (object.geometry) {
+                object.geometry.dispose();
+            }
+        }
+
         function createBoard() {
             // Clear existing cells
             cellObjects.forEach(obj => scene.remove(obj));
@@ -291,16 +307,18 @@
             const cellSize = 1.5;
             const gap = 0.05;
             const totalSize = boardSize * (cellSize + gap);
-            const offset = totalSize / 2;
+            const totalDepth = boardDepth * (cellSize + gap);
+            const offsetX = totalSize / 2;
+            const offsetY = totalDepth / 2;
             
             // Create board base
-            const boardGeometry = new THREE.BoxGeometry(totalSize + 1, 0.3, totalSize + 1);
+            const boardGeometry = new THREE.BoxGeometry(totalSize + 1, totalDepth + 0.5, totalSize + 1);
             const boardMaterial = new THREE.MeshStandardMaterial({ 
                 color: COLORS.board,
                 roughness: 0.8
             });
             const board = new THREE.Mesh(boardGeometry, boardMaterial);
-            board.position.y = -0.4;
+            board.position.y = -0.5;
             board.receiveShadow = true;
             scene.add(board);
             
@@ -308,48 +326,72 @@
             for (let x = 0; x < boardSize; x++) {
                 cells[x] = [];
                 for (let z = 0; z < boardSize; z++) {
-                    const isLight = (x + z) % 2 === 0;
-                    const geometry = new THREE.BoxGeometry(cellSize, 0.5, cellSize);
-                    const material = new THREE.MeshStandardMaterial({ 
-                        color: isLight ? COLORS.boardLight : COLORS.board,
-                        roughness: 0.7
-                    });
-                    const cell = new THREE.Mesh(geometry, material);
-                    cell.position.set(
-                        x * (cellSize + gap) - offset + cellSize / 2,
-                        0,
-                        z * (cellSize + gap) - offset + cellSize / 2
-                    );
-                    cell.castShadow = true;
-                    cell.receiveShadow = true;
-                    cell.userData = { 
-                        x, z, 
-                        isMine: false, 
-                        revealed: false, 
-                        flagged: false, 
-                        neighborCount: 0,
-                        isLight
-                    };
-                    scene.add(cell);
-                    cellObjects.push(cell);
-                    cells[x][z] = cell;
+                    cells[x][z] = [];
+                    for (let y = 0; y < boardDepth; y++) {
+                        const isLight = (x + y + z) % 2 === 0;
+                        const geometry = new THREE.BoxGeometry(cellSize, 0.5, cellSize);
+                        const material = new THREE.MeshStandardMaterial({ 
+                            color: isLight ? COLORS.boardLight : COLORS.board,
+                            roughness: 0.7
+                        });
+                        const cell = new THREE.Mesh(geometry, material);
+                        cell.position.set(
+                            x * (cellSize + gap) - offsetX + cellSize / 2,
+                            y * (cellSize + gap) - offsetY + cellSize / 2,
+                            z * (cellSize + gap) - offsetX + cellSize / 2
+                        );
+                        cell.castShadow = true;
+                        cell.receiveShadow = true;
+                        cell.userData = { 
+                            x, y, z, 
+                            isMine: false, 
+                            revealed: false, 
+                            flagged: false, 
+                            neighborCount: 0,
+                            isLight
+                        };
+                        scene.add(cell);
+                        cellObjects.push(cell);
+                        cells[x][z][y] = cell;
+                    }
                 }
             }
         }
         
-        function placeMines(excludeX, excludeZ) {
+        function placeMines(excludeX, excludeY, excludeZ) {
+            const totalCells = boardSize * boardSize * boardDepth;
+            const excludedCells = Math.min(
+                boardSize,
+                excludeX + 2
+            ) - Math.max(0, excludeX - 1);
+            const excludedDepth = Math.min(
+                boardDepth,
+                excludeY + 2
+            ) - Math.max(0, excludeY - 1);
+            const excludedRows = Math.min(
+                boardSize,
+                excludeZ + 2
+            ) - Math.max(0, excludeZ - 1);
+            const exclusionVolume = excludedCells * excludedDepth * excludedRows;
+            const maxPlaceable = totalCells - exclusionVolume;
+            if (mineCount > maxPlaceable) {
+                mineCount = maxPlaceable;
+            }
+
             let minesPlaced = 0;
             while (minesPlaced < mineCount) {
                 const x = Math.floor(Math.random() * boardSize);
+                const y = Math.floor(Math.random() * boardDepth);
                 const z = Math.floor(Math.random() * boardSize);
                 
                 // Don't place mine on first click or adjacent cells
                 const dx = Math.abs(x - excludeX);
+                const dy = Math.abs(y - excludeY);
                 const dz = Math.abs(z - excludeZ);
-                if (dx <= 1 && dz <= 1) continue;
+                if (dx <= 1 && dy <= 1 && dz <= 1) continue;
                 
-                if (!cells[x][z].userData.isMine) {
-                    cells[x][z].userData.isMine = true;
+                if (!cells[x][z][y].userData.isMine) {
+                    cells[x][z][y].userData.isMine = true;
                     minesPlaced++;
                 }
             }
@@ -358,26 +400,32 @@
         function calculateNeighbors() {
             for (let x = 0; x < boardSize; x++) {
                 for (let z = 0; z < boardSize; z++) {
-                    if (cells[x][z].userData.isMine) continue;
-                    
-                    let count = 0;
-                    for (let dx = -1; dx <= 1; dx++) {
-                        for (let dz = -1; dz <= 1; dz++) {
-                            const nx = x + dx;
-                            const nz = z + dz;
-                            if (nx >= 0 && nx < boardSize && nz >= 0 && nz < boardSize) {
-                                if (cells[nx][nz].userData.isMine) count++;
+                    for (let y = 0; y < boardDepth; y++) {
+                        if (cells[x][z][y].userData.isMine) continue;
+                        
+                        let count = 0;
+                        for (let dx = -1; dx <= 1; dx++) {
+                            for (let dz = -1; dz <= 1; dz++) {
+                                for (let dy = -1; dy <= 1; dy++) {
+                                    if (dx === 0 && dy === 0 && dz === 0) continue;
+                                    const nx = x + dx;
+                                    const ny = y + dy;
+                                    const nz = z + dz;
+                                    if (nx >= 0 && nx < boardSize && ny >= 0 && ny < boardDepth && nz >= 0 && nz < boardSize) {
+                                        if (cells[nx][nz][ny].userData.isMine) count++;
+                                    }
+                                }
                             }
                         }
+                        cells[x][z][y].userData.neighborCount = count;
                     }
-                    cells[x][z].userData.neighborCount = count;
                 }
             }
         }
         
-        function revealCell(x, z) {
-            if (x < 0 || x >= boardSize || z < 0 || z >= boardSize) return;
-            const cell = cells[x][z];
+        function revealCell(x, y, z) {
+            if (x < 0 || x >= boardSize || y < 0 || y >= boardDepth || z < 0 || z >= boardSize) return;
+            const cell = cells[x][z][y];
             const data = cell.userData;
             
             if (data.revealed || data.flagged) return;
@@ -394,7 +442,7 @@
             cell.material.dispose();
             cell.geometry = geometry;
             cell.material = material;
-            cell.position.y = -0.1;
+            cell.position.y -= 0.1;
             
             if (data.isMine) {
                 // Game over - mine hit
@@ -411,7 +459,9 @@
                 // Reveal neighbors recursively
                 for (let dx = -1; dx <= 1; dx++) {
                     for (let dz = -1; dz <= 1; dz++) {
-                        revealCell(x + dx, z + dz);
+                        for (let dy = -1; dy <= 1; dy++) {
+                            revealCell(x + dx, y + dy, z + dz);
+                        }
                     }
                 }
             }
@@ -438,7 +488,7 @@
             const spriteMaterial = new THREE.SpriteMaterial({ map: texture });
             const sprite = new THREE.Sprite(spriteMaterial);
             sprite.position.copy(cell.position);
-            sprite.position.y = 0.3;
+            sprite.position.y = cell.position.y + 0.4;
             sprite.scale.set(0.8, 0.8, 1);
             scene.add(sprite);
             cell.userData.numberSprite = sprite;
@@ -475,11 +525,13 @@
             let revealedCount = 0;
             for (let x = 0; x < boardSize; x++) {
                 for (let z = 0; z < boardSize; z++) {
-                    if (cells[x][z].userData.revealed) revealedCount++;
+                    for (let y = 0; y < boardDepth; y++) {
+                        if (cells[x][z][y].userData.revealed) revealedCount++;
+                    }
                 }
             }
             
-            const totalCells = boardSize * boardSize;
+            const totalCells = boardSize * boardSize * boardDepth;
             const safeCells = totalCells - mineCount;
             
             if (revealedCount === safeCells) {
@@ -508,7 +560,7 @@
                         cell.material.dispose();
                         cell.geometry = geometry;
                         cell.material = material;
-                        cell.position.y = -0.1;
+                        cell.position.y -= 0.1;
                         
                         if (cell.userData.numberSprite) {
                             scene.remove(cell.userData.numberSprite);
@@ -547,38 +599,61 @@
             
             // Clear scene - remove all game objects
             // First, remove all flags from cell userData
+            hoveredCell = null;
             cellObjects.forEach(cell => {
                 if (cell.userData.flag) {
+                    disposeObject3D(cell.userData.flag);
                     scene.remove(cell.userData.flag);
                     cell.userData.flag = null;
                 }
                 if (cell.userData.numberSprite) {
+                    if (cell.userData.numberSprite.material) {
+                        if (cell.userData.numberSprite.material.map) {
+                            cell.userData.numberSprite.material.map.dispose();
+                        }
+                        cell.userData.numberSprite.material.dispose();
+                    }
                     scene.remove(cell.userData.numberSprite);
                     cell.userData.numberSprite = null;
                 }
             });
             
             // Remove all cell objects
-            cellObjects.forEach(obj => scene.remove(obj));
+            cellObjects.forEach(obj => {
+                disposeObject3D(obj);
+                scene.remove(obj);
+            });
             cellObjects = [];
             
             // Remove any remaining sprites (number displays)
             const sprites = scene.children.filter(c => c.type === 'Sprite');
-            sprites.forEach(s => scene.remove(s));
+            sprites.forEach(s => {
+                if (s.material) {
+                    if (s.material.map) s.material.map.dispose();
+                    s.material.dispose();
+                }
+                scene.remove(s);
+            });
             
             // Remove any remaining flags (cone geometries)
             const flags = scene.children.filter(c => c.geometry && c.geometry.type === 'ConeGeometry');
-            flags.forEach(f => scene.remove(f));
+            flags.forEach(f => {
+                disposeObject3D(f);
+                scene.remove(f);
+            });
             
             // Remove board bases
-            const boards = scene.children.filter(c => c.geometry && c.geometry.type === 'BoxGeometry' && c.position.y === -0.4);
-            boards.forEach(b => scene.remove(b));
+            const boards = scene.children.filter(c => c.geometry && c.geometry.type === 'BoxGeometry' && c.position.y === -0.5);
+            boards.forEach(b => {
+                disposeObject3D(b);
+                scene.remove(b);
+            });
             
             createBoard();
             updateUI();
             
             // Reset camera
-            camera.position.set(0, boardSize * 1.5, boardSize * 1.2);
+            camera.position.set(0, boardSize * 1.8, boardSize * 1.4);
             controls.target.set(0, 0, 0);
         }
         
@@ -602,13 +677,13 @@
                 if (!gameStarted) {
                     gameStarted = true;
                     startTime = Date.now();
-                    placeMines(data.x, data.z);
+                    placeMines(data.x, data.y, data.z);
                     calculateNeighbors();
                     startTimer();
                 }
                 
                 if (!data.flagged) {
-                    revealCell(data.x, data.z);
+                    revealCell(data.x, data.y, data.z);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Extend the game from a flat 2D grid to a stacked 3D board so multiple layers of cells can be played. 
- Prevent memory leaks and dangling GPU resources by disposing Three.js geometries and materials when objects are removed or replaced.
- Adjust board visuals and interactions to work with a 3D coordinate system.

### Description
- Introduce a `boardDepth` variable and update board, cell creation, camera placement, and offsets to support a 3D grid of size `boardSize x boardDepth x boardSize` instead of 2D. 
- Convert cell data and arrays to include `y` (layer) coordinates and update `createBoard`, `placeMines`, `calculateNeighbors`, `revealCell`, `checkWin`, and input handlers to operate in 3D; function signatures changed to `placeMines(excludeX, excludeY, excludeZ)` and `revealCell(x, y, z)`. 
- Add `disposeObject3D` helper and explicit disposal for mesh geometries, materials, and texture maps when clearing or replacing objects, and update cleanup in `startNewGame` to remove flags, sprites, boards, and cell meshes safely. 
- Adjust visuals and positioning including board thickness, board position, revealed cell offsets, number sprite height calculation, and camera reset position, and add logic to cap `mineCount` when exclusion volume would otherwise prevent placing mines.

### Testing
- No automated tests were added or run as the project currently has no test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f82abe1083289d1b8a89fb4e18f6)